### PR TITLE
Update Sponsors page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ planning documents.
 
 [Catering and venue](./catering-and-venue.md)
 
-[Sponsorship](./sponsorship.md): for sponsors
-
 [Set up Eventbrite and handle registration](./how-to-set-up-registration.md)
 
 [What to do on Friday](./friday.md)
@@ -40,6 +38,8 @@ workshops. If someone can't make it to this one, direct them there.
 [list]: http://railsbridgeboston.us6.list-manage.com/subscribe?u=1b4272afae4569dec6efb74bb&id=1ec91857a1
 
 ## Other
+
+[Sponsorship](./sponsorship.md): information for potential sponsors
 
 [Useful links](./useful-links.md)
 

--- a/sponsorship.md
+++ b/sponsorship.md
@@ -1,16 +1,22 @@
-# Sponsors!
+# Sponsors
 
-RailsBridge Boston has been holding free workshops, starting in August 2012, in order to introduce more women to web development with Ruby on Rails, with a long term goal of increasing the number of women in the Ruby community and the software development industry.
+Since August 2012, RailsBridge Boston has been running free workshops to
+introduce women to programming in Ruby and web development with Ruby on Rails.
+The long term goal was to increase the number of women in the Ruby community and
+the software development industry.
 
-This is made possible through a number of great volunteers and sponsors- we have held numerous workshops so far at the Microsoft NERD Center, Harvard Law School, MIT Stata Center, and the Intelligent.ly office, with very positive feedback from participants.
+This is made possible through a number of great volunteers and sponsors. We have
+held numerous workshops so far at the Microsoft NERD Center, Harvard Law School,
+MIT Stata Center, and the Intelligent.ly office, with very positive feedback
+from participants.
 
-Each workshop needs about 10 sponsors, each of whom would donate about $400.00 in order to provide food for Friday night and all Saturday.
+Each workshop needs about 5-10 sponsors, each of whom would contribute towards
+food and drinks for the entire workshop and the post-workshop celebration.
 
-Each sponsor can participate by calling in a payment information to one of the specified vendors a few days before the workshop. Unfortunately, this is not tax-deductible, but we are working on solving this for future workshops.
+For more information on sponsorship and the current options, please take a look
+at the [prospectus].
 
-As a sponsor, your company logos will be displayed on our website when you are invited to attend our Friday night session, as well as attend the after-party on Saturday . You'll be able to introduce yourself to new talents, and remind the 20+ experienced TAs of your organization's commitment to a more diverse workforce!
-
-Thank you for your past and on-going sponsorship.
+[prospectus]: http://railsbridgeboston.org/sponsorship_prospectus.pdf
 
 # Financial Logistics
 RailsBridge Boston is working with [Bridge Foundry](https://atrium.schoolfactory.org/bridgefoundry/dashboard). Bridge Foundry was

--- a/sponsorship.md
+++ b/sponsorship.md
@@ -21,15 +21,3 @@ As a volunteer organization, we found the process for creating a 501(c)3 to be t
 Sponsor donations are made to Bridge Foundry, and Bridge Foundry makes the funds available to us through a debit card. This is simpler than our old process, which was to have sponsors pay vendors directly.
 
 You can read more about [Bridge Foundry's financial process here](https://atrium.schoolfactory.org/bridgefoundry/node/109312).
-
-
-***
-
-# Step-wise Guide to Sponsoring the Most Awesome Workshop Ever!
-## Step 1 ) Read the [Prospectus page](http://www.railsbridgeboston.org/prospectus.pdf)
-## Step 2) Contact the RailsBridge Boston sponsorship coordinator at railsbridgeboston@gmail.com . We'll work with you to get your logo for our website.
-## Step 3) [Send a check to Bridge Foundry](https://atrium.schoolfactory.org/bridgefoundry/node/108426)
-## Step 4) Attend the Friday Installfest! We invite sponsors to introduce themselves before the InstallFest starts.
-## Step 5) Feel free to stay throughout the workshop, otherwise, come back for the after-party at the end of the Saturday session.
-
-Thank you again for your support.

--- a/sponsorship.md
+++ b/sponsorship.md
@@ -19,11 +19,23 @@ at the [prospectus].
 [prospectus]: http://railsbridgeboston.org/sponsorship_prospectus.pdf
 
 # Financial Logistics
-RailsBridge Boston is working with [Bridge Foundry](https://atrium.schoolfactory.org/bridgefoundry/dashboard). Bridge Foundry was
-started by the RailsBridge San Francisco community in order to provide infrastructure for outreach programs in technology.
+As of December 2013, we've moved to using [Bridge Foundry] to handle our
+financials, as well as that of other RailsBridge chapters.
 
-As a volunteer organization, we found the process for creating a 501(c)3 to be too long (two years on average).  We want to make donations tax deductible for our sponsors,  as well as ensure our financial processes remain smooth as we grow the group of volunteers organizing workshops.
+Bridge Foundry is a nonprofit group, started by the RailsBridge San Francisco
+community, that promotes outreach programs in technology and assists with the
+financial infrastructure.
 
-Sponsor donations are made to Bridge Foundry, and Bridge Foundry makes the funds available to us through a debit card. This is simpler than our old process, which was to have sponsors pay vendors directly.
+As a volunteer organization, we found the process for creating a 501(c)3 to be
+too long (two years on average). We wanted to make donations tax deductible for
+our sponsors, as well as ensure our financial processes remain smooth as we
+grow the group of volunteers organizing workshops.
 
-You can read more about [Bridge Foundry's financial process here](https://atrium.schoolfactory.org/bridgefoundry/node/109312).
+Sponsor donations are made to Bridge Foundry, and Bridge Foundry makes the funds
+available to us through a debit card. This is simpler than our old process,
+which was to have sponsors pay vendors directly.
+
+You can read more about Bridge Foundry's financial process [here].
+
+[Bridge Foundry]: http://bridgefoundry.org/
+[here]: https://atrium.schoolfactory.org/bridgefoundry/node/109312


### PR DESCRIPTION
A lot of the information is the same as what's on the sponsorship prospectus, which is now linked. The process has also changed a little bit, so potential sponsors should follow instructions as mentioned in the prospectus instead.