### PR TITLE
Better explain announcing and creating an event

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,19 @@ details form. Here are some things you can use to fill out that form:
   two-day workshop that Ruby on Rails to women in the Boston community.
 * Event logo: Use [this file](/logos/logo.png).
 
-You can create a *private* (password-protected) copy of a past Eventbrite event by clicking [this link].
+Create a *private* (password-protected) copy of the most recent Eventbrite
+event. Instructions are in the [eventbrite doc](/eventbrite.md).
 
 To make it private, scroll down to "3. Additional Settings", click "Private
 page", and add a password. Now you have something to fill in the "Event
 registration link" with.
 
 It will still pop up on the RailsBridge Boston web site, which pulls in
-Eventbrite events automatically. To hide registrations links, run `heroku
-config:set HIDE_REGISTRATION=true -a railsbridge-boston`.
+Eventbrite events automatically. You should hide it by running:
 
-[this link]: https://www.eventbrite.com/copy?eid=14742277549&crumb=79144f8705126c
+```
+heroku config:set HIDE_REGISTRATION=true -a railsbridge-boston
+```
 
 ## 8 weeks before (Sponsorship Coordinator)
 
@@ -81,23 +83,17 @@ created (see above under venue), but:
 
 ## 3 weeks before (Registration Coordinator)
 
-Open up registration (all passwords are [here][private]):
+Open up registration. Step-by-step information on announcing the newly-open
+registration is in [this document](/announce-registration.md).
 
-* Make the event live in Eventbrite
-* Announce the workshop to the mailing list
-* Announce the workshop on twitter
-
-More information is in [this document](/how-to-set-up-registration.md).
+Plan to spend 30-60 minutes per day on the RBB email account after registration
+opens; we have some [answers to FAQs](/how-to-set-up-registration.md#faqs).
 
 Student registration usually fills up in a day. We open up TA registration a
 week after student registration so that we know how many students will attend.
 Both ticket types (student and TA) should stop accepting new entries about a
 week before the event so that we can review and accept TAs, print out name tags,
 etc.
-
-Don't forget to unhide registrations links on the RailsBridge site:
-
-    heroku config:set HIDE_REGISTRATION=true -a railsbridge-boston
 
 ## 2 weeks before (Organizer)
 
@@ -109,7 +105,6 @@ We place catering orders ~1.5 weeks before the workshop. We assume about 100
 people will attend, but double check that number. For more information, see
 [this document](/catering.md).
 
-
 ## 1 week before (Venue Coordinator)
 
 Find and book a bar/restaurant for our after-party at least a week in advance.
@@ -119,6 +114,10 @@ For more information see our [after party venues doc](/after-party-venues.md).
 
 Make sure the docs are updated and any changes to Installfest VMs are live on
 the website.
+
+Remind attendees about attending (instructions [here][remind]).
+
+[remind]: /how-to-set-up-registration.md#week-of-workshop
 
 ## 1 week before (MC)
 
@@ -199,6 +198,9 @@ programmers. Look at our [Friday TA pep talk](/ta-pep-talk/friday.md).
 * Bring badges for TAs
 * Bring colored dot stickers for students so we know they went through the
   Installfest
+* Handle Eventbrite check-ins as detailed [here][friday-registration]
+
+[friday-registration]: /how-to-set-up-registration.md#friday-of-the-workshop
 
 ## Saturday, the big event (Everyone)
 

--- a/announce-registration.md
+++ b/announce-registration.md
@@ -1,0 +1,74 @@
+# Announcing Registration
+
+All credentials for Mailchimp, Eventbrite, Twitter, etc can be found in [this
+repo][credentials].
+
+[credentials]: https://github.com/railsbridge-boston/private/blob/master/credentials.md
+
+## Make the event live
+
+Sign into Eventbrite and find the appropriate event in [Your Events][events].
+
+[events]: https://www.eventbrite.com/myevents/
+
+Mark the event as live and ensure it's not password-protected.
+
+## Unhide registration links on the RBB site
+
+Don't forget to unhide registrations links on the RailsBridge site:
+
+```
+heroku config:set HIDE_REGISTRATION=false -a railsbridge-boston
+```
+
+## Mailchimp: Announce to the mailing list
+
+This will create a campaign to send the announcement to the Upcoming Workshops
+mailing list.
+
+NOTE: This can be done ahead of time and saved until the announcement can be
+sent out.
+
+First, sign in to Mailchimp using the credentials [here].
+
+[here]: https://github.com/railsbridge-boston/private/blob/master/credentials.md
+
+1. Click "Create Campaign" in the top right of the dashboard
+1. Select "Regular Campaign" and go to the next setp
+1. Select the "Tell me about the next RBB workshop" list
+  1. Select the entire list
+  1. Go to next step
+1. Enter/confirm the campaign details.
+   1. Campaign name: June 2015 (or whatever month/year) Workshop Announcement
+   1. From Name: RailsBridge Boston
+   1. Email subject: Next RailsBridge Boston Workshop - Applications Open
+   1. Reply-to email address: `railsbridgeboston@gmail.com`
+   1. Personalize the `To:` field: `*|FNAME|*`
+   1. Track opens
+   1. Authenticate campaign
+   1. Go to next step
+1. Select "Saved Templates"
+1. Select the appropriate workshop announcement template, i.e. either the Ruby
+   one or the Rails one.
+1. Select the corresponding section to edit the following information:
+   1. Meta text at very top: "RailsBridge Boston [Month] workshop registration
+      is open!"
+   1. Main content: "[Month] Workshop"
+   1. Main content:  Dates, location, and URLs
+   1. Add any mentions of sponsors if necessary
+   1. Update what the workshop will cover: is it Ruby basics or Rails?
+1. Preview and test
+1. Save
+1. Look over the Plain Text version and go to next step.
+1. Confirm the information. Exit if you are not ready to send the campaign; send
+   now if you are.
+
+## Announce on twitter
+
+Sign in to Twitter and tweet about the workshop, linking to the Eventbrite page.
+
+## Tell relevant groups
+
+Send a message to relevant groups like DevChix, Boston Ruby, RailsBridge.
+
+Possibly: The Girl Develop It and Womens Coding Collective.

--- a/eventbrite.md
+++ b/eventbrite.md
@@ -1,0 +1,45 @@
+## Create an Eventbrite event
+
+1. This can be done well in advance; EventBrite keeps drafts private until you
+   make them live.
+
+2. Check the [private repo][credentials] for the RailsBridge Eventbrite account
+   login information.
+
+3. Copy the event page from the last workshop
+   (http://help.eventbrite.com/customer/portal/articles/426069-copy-an-event-page)
+
+4. Update the relevant information for the new workshop: *dates*, *location*,
+   *number of tickets* available.
+
+  Note that the event dates appear in several places, including the confirmation
+  email text. The format for the custom URL is: railsbridgeboston[month and year
+  of event].eventbrite.com.  For the Ruby workshop, be super-explicit that it's a
+  mostly self-paced tutorial and that it doesn't include Rails.
+
+5. Update the Order Confirmation page with the same info.
+
+6. Re-evaluate the number of tickets available.
+
+    The fire code limits us to 120 people (participants and TAs both) at the NERD
+    center.  We aim for 1 TA per 3 participants, so that's about 90 participants and
+    30 TAs.  For workshop 7 (January) we started with 110 tickets, which was about
+    perfect - 89 participants after cancellations, 82 showed up.  For workshops 5
+    and 6 we kept 90 available, churned through the waitlist, and had about 50
+    attendees.  We've been raising the initial number of tickets.
+
+    Eventbrite will automatically trigger the waitlist when all tickets are sold,
+    but will NOT offer tickets to people on the wait list if tickets become
+    available through cancellation.
+
+7. Make sure the childcare question is re-enabled or re-added.
+
+  It should be a radio button question that says, "Thanks to thoughtbot, we're
+  offering free in-home childcare through Parents in a Pinch. Do you need backup
+  childcare to attend the workshop?"
+
+  Add a secondary text field question for "Yes" answers that says, "Please provide
+  us with your phone #.  The child care coordinator will contact you to make
+  arrangements."
+
+[credentials]: https://github.com/railsbridge-boston/private/blob/master/credentials.md

--- a/how-to-set-up-registration.md
+++ b/how-to-set-up-registration.md
@@ -1,89 +1,9 @@
-## CREATE AN EVENTBRITE EVENT
-
-1. This can be done well in advance; EventBrite keeps drafts private until you
-   make them live.
-
-2. Ask an organizer for the RailsBridge Eventbrite account login information.
-
-3. Copy the event page from the last workshop
-   (http://help.eventbrite.com/customer/portal/articles/426069-copy-an-event-page)
-
-4. Update the relevant information for the new workshop: *dates*, *location*,
-   *number of tickets* available.
-
-  Note that the event dates appear in several places, including the confirmation
-  email text. The format for the custom URL is: railsbridgeboston[month and year
-  of event].eventbrite.com.  For the Ruby workshop, be super-explicit that it's a
-  mostly self-paced tutorial and that it doesn't include Rails.
-
-5. Update the Order Confirmation page with the same info.
-
-6. Reevaluate the number of tickets available.
-
-The fire code limits us to 120 people (participants and TAs both) at the NERD
-center.  We aim for 1 TA per 3 participants, so that's about 90 participants and
-30 TAs.  For workshop 7 (January) we started with 110 tickets, which was about
-perfect - 89 participants after cancellations, 82 showed up.  For workshops 5
-and 6 we kept 90 available, churned through the waitlist, and had about 50
-attendees.  We've been raising the initial number of tickets.
-
-EventBrite will automatically trigger the waitlist when all tickets are sold,
-but will NOT offer tickets to people on the wait list if tickets become
-available through cancellation.
-
-7. Make sure the childcare question is re-enabled or re-added.
-
-It should be a radio button question that says, "Thanks to thoughtbot, we're
-offering free in-home childcare through Parents in a Pinch. Do you need backup
-childcare to attend the workshop?"
-
-Add a secondary text field question for "Yes" answers that says, "Please provide
-us with your phone #.  The child care coordinator will contact you to make
-arrangements."
-
-##  CREATE A MAILING CAMPAIGN
-Create a campaign to send the announcement to the Upcoming Workshops mailing list.
-NOTE: This can be done ahead of time and saved until the announcement can be sent out.
-
-1. Ask an organizer for the MailChimp account login information.
-2. Click Create Campaign    NOTE: MailChimp automatically saves all your changes.
-3. Select "Regular Campaign" [Go to the next step.]
-4. Select "Send to entire list" [Next step.]
-5. Enter/confirm the campaign details.
-      * Campaign name = [Month/year of the workshop] Workshop Announcement
-      * From Name = RailsBridge Boston
-      * Email subject = Next RailsBridge Boston Workshop - Applications Open
-      * Reply-to email address = railsbridgeboston@gmail.com
-      * Personalize the To: field = *|FNAME|*
-      * Track opens
-      * Authenticate campaign [Next step.]
-6. Select "Saved Templates"
-7. Select the appropriate workshop announcement template, i.e. either the Ruby
-one or the Rails one.
-8. Select the corresponding section to edit the following information:
-      * Meta text at very top - "RailsBridge Boston [Month] workshop registration is open!"
-      * Main content - "[Month] Workshop"
-      * Main content -  Dates, location, and URLs
-      * Add any mentions of sponsors if necessary
-      * Update what the workshop will cover - is it Ruby basics or Rails?
-9. Preview and test
-10. Save
-11. Look over the Plain Text version [Next step.]
-12. Confirm the information. Exit if you are not ready to send the campaign; send now if you are.
-
-## OPEN REGISTRATION
-1. Use the campaign you created in MailChimp to notify the Upcoming Workshops mailing list about the new workshop.
-2. Announce the workshop to the rest of the world:
-     * Update the front page of the RailsBridge Boston site. Work with an organizer to push to heroku if necessary.
-     * Ask the Twitter organizer or the person in charge of the RailsBridgeBos account to post
-     * Send a message to relevant groups (DevChix, Boston Ruby, RailsBridge. Possibly: The Girl Develop It and Womens Coding Collective.)
-
 ## MANAGE REGISTRATION
+
 1. Plan to spend 30-60 minutes on email a day for the first few days after registration opens. The questions will tend to be "it's sold out, can I bring a guest?", "is this workshop a good fit?", "I'm on the waitlist, am I in?", and "please add this sponsor's employee to the list". It tapers off quickly. (_Note: there has been less email overhead with Eventbrite. Update this estimate if the trend continues._)
 2. RBB #5 and #6 filled up within a day and a half. Eventbrite will automatically open the wait list when registration is full.
 3. Post an update after registration is full using the EventBrite "News and Updates" feature. Post a description of what wait list members could expect so they can plan. The update helps in reducing the number of email questions. People will still join the wait list.
-3. Read through the registrations. To export the registration info to Excel, go to Event Reports and create a Survey Question report (http://help.eventbrite.com/customer/en_us/portal/articles/428605-attendee-summary-
-report).
+3. Read through the registrations. To export the registration info to Excel, go to Event Reports and create a Survey Question report (http://help.eventbrite.com/customer/en_us/portal/articles/428605-attendee-summary-report).
      * There is no "and guest" - everyone must register.
      * For men participants, check that they have a female host and that she has registered.
      * Check for duplicate entries.
@@ -122,6 +42,7 @@ NOTE: EventBrite has a name tag feature. The free version doesn't allow logos.  
 
 
 ## FRIDAY OF THE WORKSHOP
+
  1. Two people should be doing check-ins. People often came in groups and it's sometimes tough to process them all at once. Make sure both can log in to EventBrite and they have the EventBrite app on their device before showtime. The EventBrite phone app will sync check-in data from multiple devices.
 2. Track how many people attended vs. no-shows so we can make better predictions in future.
 
@@ -133,7 +54,8 @@ NOTE: EventBrite has a name tag feature. The free version doesn't allow logos.  
        (see http://help.eventbrite.com/customer/en_us/portal/articles/428605-attendee-summary-report)
      * Open it in Excel; Remove anyone who opted out of email sharing.
 
-## Q&A
+## FAQs
+
 **How many spots can we offer?**
 
 Ideally every seat will be filled, but it's challenging. The fire code gives us a hard limit of how many people may be at the workshop site. There are always cancellations, but we don't have a good formula to predict how many. Most cancellations come in on Friday, and many waitlisters have made other plans. We're going to track attendance better so we have more data.


### PR DESCRIPTION
* We already have good explanations of Eventbrite and Mailchimp registration, so make them easier to find via the README
* Move Eventbrite event creation explanation to its own file, `eventbrite.md`
* Split off registration announcement instructions (as opposed to actually creating an event people can register for) into `announce-registration.md`