### PR TITLE
Updates to coordination timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,14 @@ opens; we have some [answers to FAQs](/how-to-set-up-registration.md#faqs).
 
 ## 1.5 weeks before (Catering Coordinator)
 
-We place catering orders ~1.5 weeks before the workshop. We assume about 75% of
-the people who registered + number of TA's will attend, but double check that
-number. For more information, see [this document](/catering.md).
+Find 2-3 different vendors that we can work with. If our venue has a specific
+list of vendors we can use, please accommodate that.
+
+Get a CSV of all the attendees, including TAs, to get a rough head count and a
+sense of what the dietary restrictions are.
+
+Assume about 60% of the people who registered + number of TA's will attend.  For
+more information, see [this document](/catering.md).
 
 ## 1 week before (Child Care Coordinator)
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,6 @@ our babysitter and children can stay in.
 Create a *private* (password-protected) copy of the most recent Eventbrite
 event. Instructions are in the [eventbrite doc](/eventbrite.md).
 
-To make it private, scroll down to "3. Additional Settings", click "Private
-page", and add a password.
-
 It will still pop up on the RailsBridge Boston web site, which pulls in
 Eventbrite events automatically. You should hide it by running:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ people may have last-minute questions, cancellations, or maybe child care reques
 It would also be good to check often right after a workshop has happened as
 well.
 
-## 6 months before (Venue Coordinator)
+## 6 months before
+
+### Venue Coordinator
 
 Book a venue for the event. It should be free, hold at least 100 people, and be
 as easily accessible as possible (e.g. the T, parking).
@@ -47,6 +49,8 @@ preferred vendors, where should they come in, etc.), security, etc.
 
 If we're offering onsite childcare, we make sure there's a separate room that
 our babysitter and children can stay in.
+
+### Registration Coordinator
 
 Create a *private* (password-protected) copy of the most recent Eventbrite
 event. Instructions are in the [eventbrite doc](/eventbrite.md).

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ The RailsBridge Boston website will automatically fetch details about the event
 and display it. For now, hide that section temporarily by setting the
 `HIDE_REGISTRATION` variable to `true`.
 
+## 3 months before (Organizer)
+
+Set up a coordination meeting for everyone who's interested in coordinating for
+the next workshop.
+
 ## 8 weeks before (Sponsorship Coordinator)
 
 Start emailing potential sponsors. There's more in the [sponsorship
@@ -80,10 +85,6 @@ Unhide registration on the website by setting `HIDE_REGISTRATION` to `false`.
 
 Plan to spend 30-60 minutes per day on the RBB email account after registration
 opens; we have some [answers to FAQs](/how-to-set-up-registration.md#faqs).
-
-## 2 weeks before (Organizer)
-
-Find an MC.
 
 ## 1.5 weeks before (Catering Coordinator)
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,12 @@ and display it. For now, hide that section temporarily by setting the
 
 ## 3 months before (Organizer)
 
-Set up a coordination meeting for everyone who's interested in coordinating for
-the next workshop.
+Create a new Trello board based on the [Workshop Template].
+
+Set up a meeting for everyone who's interested in coordinating for the next
+workshop and invite them to the new Trello board.
+
+[Workshop Template]: https://trello.com/b/AIqOY0yW/workshop-template
 
 ## 8 weeks before (Sponsorship Coordinator)
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Ask a lead organizer for access to credentials to the various services we use.
 Here's a list of roles that are involved in organizing a workshop:
 
 * 1-2 Lead Organizers
-* Venue Coordinator: changes with each workshop, whoever does it should commit
-  to owning the process
+* Venue Coordinator - The venue may change with each workshop. Whoever does it
+should commit to owning the process and maintaining communication with the venue
+contact(s).
 * Registration Coordinator
 * Catering Coordinator
 * Sponsorship Coordinator

--- a/README.md
+++ b/README.md
@@ -104,8 +104,10 @@ them an email (all BCC'ed), explaining how it works, have them confirm that they
 still need care, and if so, ask them for details about their children (age,
 gender, special needs, which days and how long they need care for).
 
-Give them 2-3 days to respond to you. Coordinate payment between the sponsor and
-the child care provider.
+Give them 2-3 days to respond to you.
+
+Use Sitter City to find a sitter that would accommodate the children that need
+care. Be sure to coordinate how payment will work with the sitter.
 
 ## 1 week before (Venue Coordinator)
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,21 @@ contact(s).
 This is year-round task that involves monitoring the inbox and answering any
 questions about the organization or the events we run.
 
+We use [Inbox by Zendesk][inbox] to manage emails sent to the RBB. Anything that
+is sent to the RBB address is automatically forwarded to our personal ones.
+
+If there are multiple people managing the inbox, please make sure to assign
+yourself to the email threads that you are participating in. If a conversation
+is complete, please also mark it as "Done".
+
 Checking in on a weekly basis in between workshops should suffice. As we get
 closer to a workshop though, the inbox should be checked more frequently since
 people may have last-minute questions, cancellations, or maybe child care requests.
 
 It would also be good to check often right after a workshop has happened as
 well.
+
+[inbox]: https://www.zendesk.com/inbox/
 
 ## 6 months before
 

--- a/README.md
+++ b/README.md
@@ -109,23 +109,29 @@ Give them 2-3 days to respond to you.
 Use Sitter City to find a sitter that would accommodate the children that need
 care. Be sure to coordinate how payment will work with the sitter.
 
-## 1 week before (Venue Coordinator)
+## 1 week before
+
+### Venue Coordinator
 
 Find and book a bar/restaurant for our after-party at least a week in advance.
 For more information see our [after party venues doc](/after-party-venues.md).
 
-## 1 week before (Organizer)
+### Installfest Coordinator
 
 Make sure the docs are updated and any changes to Installfest VMs are live on
 the website.
+
+Run the spoon-building script to update the download files.
+
+### Registration Coordinator
 
 Remind attendees about attending (instructions [here][remind]).
 
 [remind]: /how-to-set-up-registration.md#week-of-workshop
 
-## 1 week before (MC)
+### MC
 
-MC should ready a  slide deck with:
+Prepare a slide deck with:
 
 * Sponsor logos
 * Link to Friday/Saturday Google docs

--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ Prepare a slide deck with:
 
 We have sample slide decks in [the MC directory](/mc).
 
-## 3 days before (Venue Coordinator)
+## 3 days before
+
+### Venue Coordinator
 
 Send NERD a list of names of everyone who might be there.
 
@@ -156,8 +158,10 @@ Send NERD a list of names of everyone who might be there.
   our NERD Center contact is and the lead coordinators. Re-emphasize that we
   want the desks set up in U shaped clusters.
 
-Send an Eventbrite email to everyone, TAs *and* students, asking them to be sure
-that they bring a photo ID, per NERD Center policy.
+### Registration Coordinator
+
+If applicable, send an Eventbrite email to everyone about remembering their IDs
+for front security.
 
 ## Friday afternoon (Organizer)
 

--- a/README.md
+++ b/README.md
@@ -55,12 +55,13 @@ our babysitter and children can stay in.
 Create a *private* (password-protected) copy of the most recent Eventbrite
 event. Instructions are in the [eventbrite doc](/eventbrite.md).
 
-It will still pop up on the RailsBridge Boston web site, which pulls in
-Eventbrite events automatically. You should hide it by running:
+Copy the event ID from the Eventbrite URL and update the `NEXT_EVENT_ID`
+environment variable on Heroku using that value. If you don't have Heroku access
+to the app, ask a Lead Organizer for access or for them to update it for you.
 
-```
-heroku config:set HIDE_REGISTRATION=true -a railsbridge-boston
-```
+The RailsBridge Boston website will automatically fetch details about the event
+and display it. To hide that section temporarily, set the `HIDE_REGISTRATION`
+variable to `true`.
 
 ## 8 weeks before (Sponsorship Coordinator)
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ contact(s).
 
 ## Answering email (Organizer)
 
-This is not around  organizing a specific event - the organizer should check in
-with email every so often.
+This is year-round task that involves monitoring the inbox and answering any
+questions about the organization or the events we run.
 
-People will have questions, especially as the event approaches and immediately
-after an event.
+Checking in on a weekly basis in between workshops should suffice. As we get
+closer to a workshop though, the inbox should be checked more frequently since
+people may have last-minute questions, cancellations, or maybe child care requests.
+
+It would also be good to check often right after a workshop has happened as
+well.
 
 ## 6 months before (Venue Coordinator)
 

--- a/README.md
+++ b/README.md
@@ -73,21 +73,13 @@ document](/sponsorship.md).
 
 Update any necessary information on the event page (check the Eventbrite docs).
 
-Unhide registration on the website by setting `HIDE_REGISTRATION` to `false`.
-
-## 3 weeks before (Registration Coordinator)
-
 Open up registration. Step-by-step information on announcing the newly-open
 registration is in [this document](/announce-registration.md).
 
+Unhide registration on the website by setting `HIDE_REGISTRATION` to `false`.
+
 Plan to spend 30-60 minutes per day on the RBB email account after registration
 opens; we have some [answers to FAQs](/how-to-set-up-registration.md#faqs).
-
-Student registration usually fills up in a day. We open up TA registration a
-week after student registration so that we know how many students will attend.
-Both ticket types (student and TA) should stop accepting new entries about a
-week before the event so that we can review and accept TAs, print out name tags,
-etc.
 
 ## 2 weeks before (Organizer)
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,17 @@ well.
 Book a venue for the event. It should be free, hold at least 100 people, and be
 as easily accessible as possible (e.g. the T, parking).
 
-After booking, coordinate with the venue contact over any logistics when using
-the space, e.g.  what's off-limits, equipment use, catering, security, etc.
+The timeframes we need are: **Friday 6:00-9:30pm** and **Saturday
+9:00am-5:30pm**. These timeframes include 30-minute prep/setup at the beginning
+of each day and then a little bit of time to clean up at the end. If we could
+arrive earlier to accommodate catering arrivals, that would be great.
+
+When talking to someone about the venue, be sure to ask about any logistics when
+using the space, e.g. what's off-limits, equipment use, catering (do they have
+preferred vendors, where should they come in, etc.), security, etc.
+
+If we're offering onsite childcare, we make sure there's a separate room that
+our babysitter and children can stay in.
 
 Create a *private* (password-protected) copy of the most recent Eventbrite
 event. Instructions are in the [eventbrite doc](/eventbrite.md).

--- a/README.md
+++ b/README.md
@@ -52,16 +52,17 @@ our babysitter and children can stay in.
 
 ### Registration Coordinator
 
-Create a *private* (password-protected) copy of the most recent Eventbrite
-event. Instructions are in the [eventbrite doc](/eventbrite.md).
+Once a space has been booked, create a *private* (password-protected) copy of
+the most recent Eventbrite event. Instructions are in the [eventbrite
+doc](/eventbrite.md).
 
 Copy the event ID from the Eventbrite URL and update the `NEXT_EVENT_ID`
 environment variable on Heroku using that value. If you don't have Heroku access
 to the app, ask a Lead Organizer for access or for them to update it for you.
 
 The RailsBridge Boston website will automatically fetch details about the event
-and display it. To hide that section temporarily, set the `HIDE_REGISTRATION`
-variable to `true`.
+and display it. For now, hide that section temporarily by setting the
+`HIDE_REGISTRATION` variable to `true`.
 
 ## 8 weeks before (Sponsorship Coordinator)
 
@@ -70,11 +71,9 @@ document](/sponsorship.md).
 
 ## 5 weeks before (Registration Coordinator)
 
-Set up registration. There should already be an Eventbrite event that you
-created (see above under venue), but:
+Update any necessary information on the event page (check the Eventbrite docs).
 
-* We should have 100 student tickets
-* We should have 20 TA tickets (password-protected)
+Unhide registration on the website by setting `HIDE_REGISTRATION` to `false`.
 
 ## 3 weeks before (Registration Coordinator)
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ Create a *private* (password-protected) copy of the most recent Eventbrite
 event. Instructions are in the [eventbrite doc](/eventbrite.md).
 
 To make it private, scroll down to "3. Additional Settings", click "Private
-page", and add a password. Now you have something to fill in the "Event
-registration link" with.
+page", and add a password.
 
 It will still pop up on the RailsBridge Boston web site, which pulls in
 Eventbrite events automatically. You should hide it by running:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ask a lead organizer for access to credentials to the various services we use.
 
 Here's a list of roles that are involved in organizing a workshop:
 
-* Lead Organizer
+* 1-2 Lead Organizers
 * Venue Coordinator: changes with each workshop, whoever does it should commit
   to owning the process
 * Registration Coordinator

--- a/eventbrite.md
+++ b/eventbrite.md
@@ -36,6 +36,10 @@
   It should be a radio button question that says, "Thanks to thoughtbot, we're
   offering free on-site childcare. Do you need childcare to attend the workshop?"
 
+1. Provide the Sponsorship Coordinator with the special link for TAs sent by
+sponsors. It'll look something like:
+https://railsbridgeboston012017.eventbrite.com?discount=special_invite.
+
 [credentials]: https://github.com/railsbridge-boston/private/blob/master/credentials.md
 [copying instructions]: https://www.eventbrite.com/support/articles/en_US/How_To/how-to-copy-an-event-page
 

--- a/eventbrite.md
+++ b/eventbrite.md
@@ -8,10 +8,11 @@
 
 1. [Copy the event page][copying instructions] from the last workshop.
 
-1. Update the relevant information for the new workshop: *dates*, *location*,
-   *number of tickets* available.
+1. Update key information for the new workshop: *dates*, *location*, *number of
+tickets* available.
 
-1. Update the Order Confirmation page with the same info.
+1. Add or update any important information people should know about finding the
+venue on the Order Confirmation page.
 
 1. Re-evaluate the number of tickets available.
 

--- a/eventbrite.md
+++ b/eventbrite.md
@@ -6,8 +6,7 @@
 1. Check the [private repo][credentials] for the RailsBridge Eventbrite account
    login information.
 
-1. Copy the event page from the last workshop
-   (https://www.eventbrite.com/support/articles/en_US/How_To/how-to-copy-an-event-page)
+1. [Copy the event page][copying instructions] from the last workshop.
 
 1. Update the relevant information for the new workshop: *dates*, *location*,
    *number of tickets* available.
@@ -38,6 +37,7 @@
   offering free on-site childcare. Do you need childcare to attend the workshop?"
 
 [credentials]: https://github.com/railsbridge-boston/private/blob/master/credentials.md
+[copying instructions]: https://www.eventbrite.com/support/articles/en_US/How_To/how-to-copy-an-event-page
 
 ### Ticket types
 

--- a/eventbrite.md
+++ b/eventbrite.md
@@ -59,3 +59,11 @@ There should be 3 ticket types:
     know about them at least 1-2 weeks ahead of time.
 
 Ticket "sales" should end ~1 week before the workshop.
+
+### Making the event private
+
+On the "EDIT" page:
+
+* scroll down to "Additional Settings"
+* click "Private page"
+* add a password

--- a/eventbrite.md
+++ b/eventbrite.md
@@ -11,11 +11,6 @@
 1. Update the relevant information for the new workshop: *dates*, *location*,
    *number of tickets* available.
 
-  Note that the event dates appear in several places, including the confirmation
-  email text. The format for the custom URL is: railsbridgeboston[month and year
-  of event].eventbrite.com. For the Ruby workshop, be super-explicit that it's a
-  mostly self-paced tutorial and that it doesn't include Rails.
-
 1. Update the Order Confirmation page with the same info.
 
 1. Re-evaluate the number of tickets available.
@@ -35,6 +30,12 @@
 
   It should be a radio button question that says, "Thanks to thoughtbot, we're
   offering free on-site childcare. Do you need childcare to attend the workshop?"
+
+1. Update the event URL to be more human-friendly.
+
+  On the Event Dashboard, there should be an option to edit the event URL.
+  Usually, we follow the format of: `railsbridgeboston[month and year of
+  event].eventbrite.com`.
 
 1. Provide the Sponsorship Coordinator with the special link for TAs sent by
 sponsors. It'll look something like:

--- a/eventbrite.md
+++ b/eventbrite.md
@@ -38,3 +38,18 @@
   offering free on-site childcare. Do you need childcare to attend the workshop?"
 
 [credentials]: https://github.com/railsbridge-boston/private/blob/master/credentials.md
+
+### Ticket types
+
+There should be 3 ticket types:
+  * Participant
+  * TA
+    - This should end 2 weeks before the workshop so that the TA Coordinator can
+    get back to them about whether or not they are accept. This will also give
+    people time to prepare for their presentations and look at the curriculum.
+  * Invited TA
+    - This one is reserved for TAs that are sent by sponsors.
+    - This can stay open until the very last-minute, but preferably, we should
+    know about them at least 1-2 weeks ahead of time.
+
+Ticket "sales" should end ~1 week before the workshop.

--- a/eventbrite.md
+++ b/eventbrite.md
@@ -3,23 +3,23 @@
 1. This can be done well in advance; EventBrite keeps drafts private until you
    make them live.
 
-2. Check the [private repo][credentials] for the RailsBridge Eventbrite account
+1. Check the [private repo][credentials] for the RailsBridge Eventbrite account
    login information.
 
-3. Copy the event page from the last workshop
+1. Copy the event page from the last workshop
    (https://www.eventbrite.com/support/articles/en_US/How_To/how-to-copy-an-event-page)
 
-4. Update the relevant information for the new workshop: *dates*, *location*,
+1. Update the relevant information for the new workshop: *dates*, *location*,
    *number of tickets* available.
 
   Note that the event dates appear in several places, including the confirmation
   email text. The format for the custom URL is: railsbridgeboston[month and year
-  of event].eventbrite.com.  For the Ruby workshop, be super-explicit that it's a
+  of event].eventbrite.com. For the Ruby workshop, be super-explicit that it's a
   mostly self-paced tutorial and that it doesn't include Rails.
 
-5. Update the Order Confirmation page with the same info.
+1. Update the Order Confirmation page with the same info.
 
-6. Re-evaluate the number of tickets available.
+1. Re-evaluate the number of tickets available.
 
     The fire code limits us to 120 people (participants and TAs both) at the NERD
     center.  We aim for 1 TA per 4 participants, so that's about 96 participants and
@@ -32,7 +32,7 @@
     but will NOT offer tickets to people on the wait list if tickets become
     available through cancellation.
 
-7. Make sure the childcare question is re-enabled or re-added.
+1. Make sure the childcare question is re-enabled or re-added.
 
   It should be a radio button question that says, "Thanks to thoughtbot, we're
   offering free on-site childcare. Do you need childcare to attend the workshop?"

--- a/ta-pep-talk.md
+++ b/ta-pep-talk.md
@@ -1,4 +1,16 @@
-# TA Pep Talk (Saturday)
+# TA Pep Talk
+
+## Friday
+
+Get the TAs all together and emphasize the following points:
+
+* Never, ever take the keyboard away from people. It's hard, but guide them
+  through doing things themselves.
+* Windows is generally harder to set up than other OSes. Please don't make jokes
+  about how "windows sucks" - it's hard enough to be here without that, and
+  people will hear it.
+
+## Saturday
 
 Get the TAs all together and emphasize the following points:
 
@@ -11,5 +23,3 @@ Get the TAs all together and emphasize the following points:
 * Sometimes people just don't ask questions. Check in with people every so
   often; a quick "Can I help anyone? Are you suuuure?" can go a long way.
 * Encourage TAs to give out their contact information if they want to.
-
-[Friday]: /ta-pep-talk/friday.md

--- a/ta-pep-talk/friday.md
+++ b/ta-pep-talk/friday.md
@@ -1,9 +1,0 @@
-# TA Pep Talk (Friday)
-
-Get the TAs all together and emphasize the following points:
-
-* Never, ever take the keyboard away from people. It's hard, but guide them
-  through doing things themselves.
-* Windows is generally harder to set up than other OSes. Please don't make jokes
-  about how "windows sucks" - it's hard enough to be here without that, and
-  people will hear it.


### PR DESCRIPTION
There's a lot of outdated information and this fixes most of that stuff. More to come!

Some highlights:

* Include info about hiding/displaying registration info on the website
* Include info about doing the spoon-building 

Check out the commits for more info.